### PR TITLE
Feature: syntax highlighting improvements to Rust

### DIFF
--- a/themes/Kimbie Dark+-color-theme.json
+++ b/themes/Kimbie Dark+-color-theme.json
@@ -157,7 +157,9 @@
         "keyword.other.forall.haskell",
         "keyword.other.arrow.haskell",
         "keyword.other.big-arrow.haskell",
-        "keyword.other.double-colon.haskell"
+        "keyword.other.double-colon.haskell",
+        "variable.language.rust",
+        "keyword.operator.misc.rust"
       ],
       "settings": {
         "foreground": "#98676a"
@@ -456,8 +458,9 @@
       }
     },
     {
-      "name": "Preprocessor",
+      "name": "Preprocessors and attributes",
       "scope": [
+        "meta.attribute.rust",
         "meta.preprocessor.haskell",
         "keyword.other.preprocessor.haskell"
       ],


### PR DESCRIPTION
Added syntax coloring to Rust attributes:
![derive](https://user-images.githubusercontent.com/24278257/73588621-f8223100-44d3-11ea-80b3-75ebc2f338a0.png)

Added syntax coloring to rust operator `as`. Since it is colored using `keyword.operator.misc.rust`, some other operators get colored as well.
![as](https://user-images.githubusercontent.com/24278257/73588636-26077580-44d4-11ea-981b-09409cb4baa7.png)

Added `variable.language.rust` to keywords highlighting group, in order to highlight `self` as a keyword
![self](https://user-images.githubusercontent.com/24278257/73588739-6287a100-44d5-11ea-90b5-674e468050f7.png)
