### PR TITLE
Feature: Add syntax highlighting for YARD documentation in ruby

### DIFF
--- a/themes/Kimbie Dark+-color-theme.json
+++ b/themes/Kimbie Dark+-color-theme.json
@@ -129,7 +129,9 @@
         "punctuation.definition.string",
         "punctuation.definition.array",
         "punctuation.definition.entity",
-        "punctuation.separator.inheritance"
+        "punctuation.separator.inheritance",
+        "comment.line.keyword.punctuation.yard",
+        "comment.line.punctuation.yard",
       ],
       "settings": {
         "foreground": "#d3af86"
@@ -162,7 +164,8 @@
         "keyword.other.double-colon.haskell",
         "variable.language.rust",
         "keyword.operator.misc.rust",
-        "variable.language"
+        "variable.language",
+        "comment.line.keyword.yard"
       ],
       "settings": {
         "foreground": "#98676a"
@@ -173,7 +176,8 @@
       "scope": [
         "variable",
         "variable.parameter.function",
-        "support.variable.property"
+        "support.variable.property",
+        "comment.line.parameter.yard"
       ],
       "settings": {
         "foreground": "#dc3958"
@@ -198,7 +202,8 @@
         "entity.name.class",
         "entity.name.type",
         "variable.other.constant.elixir",
-        "entity.other.inherited-class"
+        "entity.other.inherited-class",
+        "comment.line.type.yard"
       ],
       "settings": {
         "foreground": "#f06431"


### PR DESCRIPTION
![yarddoc](https://user-images.githubusercontent.com/24278257/74149774-396fba80-4c11-11ea-8308-628340dbc3c0.png)
