### PR TITLE
Feature: Fixes to foreground displaying

### DIFF
--- a/themes/Kimbie Dark+-color-theme.json
+++ b/themes/Kimbie Dark+-color-theme.json
@@ -97,6 +97,7 @@
   },
   "tokenColors": [
     {
+      "scope": "source",
       "settings": {
         "foreground": "#d3af86"
       }
@@ -132,6 +133,8 @@
         "punctuation.separator.inheritance",
         "comment.line.keyword.punctuation.yard",
         "comment.line.punctuation.yard",
+        "punctuation.section.function.ruby",
+        "punctuation.separator.object.ruby"
       ],
       "settings": {
         "foreground": "#d3af86"


### PR DESCRIPTION
Some elements tend to get overwritten because their scopes haven't been specified to be the default foreground color. These additions fix the cases which i currently have discovered