### PR TITLE
Improvements to Typescript syntax coloring

### DIFF
--- a/themes/Kimbie Dark+-color-theme.json
+++ b/themes/Kimbie Dark+-color-theme.json
@@ -171,7 +171,8 @@
         "keyword.other.double-colon.haskell",
         "variable.language.rust",
         "variable.language",
-        "comment.line.keyword.yard"
+        "comment.line.keyword.yard",
+        "keyword.operator.expression"
       ],
       "settings": {
         "foreground": "#98676a"

--- a/themes/Kimbie Dark+-color-theme.json
+++ b/themes/Kimbie Dark+-color-theme.json
@@ -210,7 +210,7 @@
       }
     },
     {
-      "name": "Classes",
+      "name": "Classes & types",
       "scope": [
         "support.class",
         "entity.name.class",
@@ -218,7 +218,8 @@
         "variable.other.constant.elixir",
         "entity.other.inherited-class",
         "comment.line.type.yard",
-        "storage.type.struct"
+        "storage.type.struct",
+        "support.type.primitive"
       ],
       "settings": {
         "foreground": "#f06431"

--- a/themes/Kimbie Dark+-color-theme.json
+++ b/themes/Kimbie Dark+-color-theme.json
@@ -220,7 +220,8 @@
         "entity.other.inherited-class",
         "comment.line.type.yard",
         "storage.type.struct",
-        "support.type.primitive"
+        "support.type.primitive",
+        "support.type.builtin"
       ],
       "settings": {
         "foreground": "#f06431"

--- a/themes/Kimbie Dark+-color-theme.json
+++ b/themes/Kimbie Dark+-color-theme.json
@@ -196,7 +196,8 @@
         "entity.name.function",
         "meta.require",
         "support.function.any-method",
-        "support.function"
+        "support.function",
+        "keyword.operator.new"
       ],
       "settings": {
         "foreground": "#8ab1b0"


### PR DESCRIPTION
* highlighting for primitive types
* highlighting for the function name `new` 
* highlighting for Typescript-specific keywords(`keyof`, `typeof`)